### PR TITLE
fix(imports): Fix SentryHook import

### DIFF
--- a/sentry_plugin/__init__.py
+++ b/sentry_plugin/__init__.py
@@ -1,5 +1,5 @@
 from airflow.plugins_manager import AirflowPlugin
-from sentry_plugin.hooks.sentry_hook import SentryHook
+from .hooks.sentry_hook import SentryHook
 
 
 class SentryPlugin(AirflowPlugin):

--- a/sentry_plugin/hooks/sentry_hook.py
+++ b/sentry_plugin/hooks/sentry_hook.py
@@ -116,7 +116,7 @@ class SentryHook(BaseHook):
                 conn_id = self.get_connection(sentry_conn_id)
             dsn = conn_id.host
             init(dsn=dsn, integrations=integrations)
-        except (AirflowException, exc.OperationalError):
+        except (AirflowException, exc.OperationalError, exc.ProgrammingError):
             self.log.debug("Sentry defaulting to environment variable.")
             init(integrations=integrations)
 


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'sentry_plugin'` by using a relative import. Also catches an additional SQLAlchemy exception`exc.ProgrammingError` so that Airflow defaults to the `sentry_dsn` environment variable in that case.