### PR TITLE
Connection extra parameters for sentry environment

### DIFF
--- a/hooks/sentry_hook.py
+++ b/hooks/sentry_hook.py
@@ -117,10 +117,17 @@ class SentryHook(BaseHook):
             dsn = None
             conn = self.get_connection(sentry_conn_id)
             dsn = get_dsn(conn)
-            init(dsn=dsn, integrations=integrations)
+            init_args = {'dsn':dsn, 'integrations':integrations}
+
+            environment = conn.extra_dejson.get('environment')
+            if environment:
+                init_args.update({'environment':environment})
+
         except (AirflowException, exc.OperationalError, exc.ProgrammingError):
             self.log.debug("Sentry defaulting to environment variable.")
-            init(integrations=integrations)
+            init_args = {'integrations':integrations}
+
+        init(**init_args)
 
         TaskInstance._run_raw_task = add_sentry
         TaskInstance._sentry_integration_ = True

--- a/tests/test_sentry_hook.py
+++ b/tests/test_sentry_hook.py
@@ -134,3 +134,11 @@ class TestSentryHook(unittest.TestCase):
         conn = Connection(conn_type="http", login=None, host="https://foo@sentry.io/123")
         dsn = get_dsn(conn)
         self.assertEqual(dsn, "https://foo@sentry.io/123")
+
+    def test_get_environment_from_extra_parameter(self):
+        """
+        Test getting environment from extra parameter
+        """
+        conn = Connection(extra='{"environment": "development"}')
+        environment = conn.extra_dejson.get("environment")
+        self.assertEqual(environment, "development")


### PR DESCRIPTION
In our connection extra, we have the capacity for an additional parameter for our airflow project environment.

Example:
```
Conn Id: sentry_dsn
Conn Type: HTTP
Host: https://foo@sentry.io/123
Extra: {"environment": "development"}
```